### PR TITLE
Rename: Remove suffix `R1` from classes

### DIFF
--- a/docs/source/rst/get_started.rst
+++ b/docs/source/rst/get_started.rst
@@ -6,8 +6,8 @@ Get started
 
 This library allows you to make boolean operations between subsets on the real line:
 
-* `EmptyR1`: An empty subset, without any elements
-* `WholeR1`: The entire real line
-* `SingleValueR1`: An subset with only one element
-* `IntervalR1`: An subset of continuous elements between 
-* `DisjointR1`: The union of `SingleValueR1` and `IntervalR1`
+* `Empty`: An empty subset, without any elements
+* `Whole`: The entire real line
+* `SingleValue`: An subset with only one element
+* `Interval`: An subset of continuous elements between 
+* `Disjoint`: The union of `SingleValue` and `Interval`

--- a/docs/source/rst/references.rst
+++ b/docs/source/rst/references.rst
@@ -1,4 +1,4 @@
-.. autoclass:: rbool.base.EmptyR1
+.. autoclass:: rbool.base.Empty
     :members:
     :inherited-members:
     :undoc-members:
@@ -6,7 +6,7 @@
 
 ----------------------------------------------------
 
-.. autoclass:: rbool.base.WholeR1
+.. autoclass:: rbool.base.Whole
     :members:
     :inherited-members:
     :undoc-members:
@@ -14,7 +14,7 @@
 
 ----------------------------------------------------
 
-.. autoclass:: rbool.singles.SingleValueR1
+.. autoclass:: rbool.singles.SingleValue
     :members:
     :inherited-members:
     :undoc-members:
@@ -22,7 +22,7 @@
 
 ----------------------------------------------------
 
-.. autoclass:: rbool.singles.IntervalR1
+.. autoclass:: rbool.singles.Interval
     :members:
     :inherited-members:
     :undoc-members:
@@ -30,7 +30,7 @@
 
 ----------------------------------------------------
 
-.. autoclass:: rbool.singles.DisjointR1
+.. autoclass:: rbool.singles.Disjoint
     :members:
     :inherited-members:
     :undoc-members:

--- a/src/rbool/__init__.py
+++ b/src/rbool/__init__.py
@@ -2,11 +2,11 @@
 Init file that includes the most used classes and functions of the module
 """
 
-from .base import EmptyR1, Future, SubSetR1, WholeR1
+from .base import Empty, Future, SubSetR1, Whole
 from .bool1d import contains, extract_knots, intersect, invert, unite
 from .converter import from_any
 from .limits import infimum, maximum, minimum, supremum
-from .singles import DisjointR1, IntervalR1, SingleValueR1, bigger, lower
+from .singles import Disjoint, Interval, SingleValue, bigger, lower
 from .transform import move, scale
 
 Future.convert = from_any

--- a/src/rbool/base.py
+++ b/src/rbool/base.py
@@ -4,11 +4,11 @@ The main purpose of this module is to be returned from analytics roots
 or when concatenating piecewise curves
 
 Here we define 5 classes:
-* EmptyR1 : Represents an empty set {} of the real line R1
-* WholeR1 : Represents the entire real line R1
-* SingleValueR1 : Represents a subset of R1 with only one finite element
-* IntervalR1 : Represents a subset of R1 with continuous points
-* DisjointR1 : Represents the union of some SingleValueR1 and IntervalR1
+* Empty : Represents an empty set {} of the real line R1
+* Whole : Represents the entire real line R1
+* SingleValue : Represents a subset of R1 with only one finite element
+* Interval : Represents a subset of R1 with continuous points
+* Disjoint : Represents the union of some SingleValue and Interval
 
 With them, we can verify if one subset contains another subset
 It's possible to make the standard boolean operations, like union,
@@ -201,11 +201,11 @@ class SubSetR1(ABC):
         return not self == other
 
 
-class EmptyR1(SubSetR1):
+class Empty(SubSetR1):
     """
-    EmptyR1 class is a singleton that represents an empty set
+    Empty class is a singleton that represents an empty set
 
-    It's equivalent to: EmptyR1 = {}
+    It's equivalent to: Empty = {}
     """
 
     instance = None
@@ -229,7 +229,7 @@ class EmptyR1(SubSetR1):
         return self
 
     def __invert__(self):
-        return WholeR1()
+        return Whole()
 
     def __and__(self, other):
         Future.convert(other)
@@ -249,7 +249,7 @@ class EmptyR1(SubSetR1):
         return r"{}"
 
     def __repr__(self):
-        return "EmptyR1"
+        return "Empty"
 
     def __eq__(self, other):
         return self is Future.convert(other)
@@ -258,11 +258,11 @@ class EmptyR1(SubSetR1):
         return 0
 
 
-class WholeR1(SubSetR1):
+class Whole(SubSetR1):
     """
-    WholeR1 class is a singleton that represents the entire real line
+    Whole class is a singleton that represents the entire real line
 
-    It's equivalent to: WholeR1 = (-inf, +inf)
+    It's equivalent to: Whole = (-inf, +inf)
     """
 
     instance = None
@@ -287,7 +287,7 @@ class WholeR1(SubSetR1):
         return self
 
     def __invert__(self):
-        return EmptyR1()
+        return Empty()
 
     def __and__(self, other):
         return Future.convert(other)
@@ -307,7 +307,7 @@ class WholeR1(SubSetR1):
         return "(" + str(NEGINF) + ", " + str(POSINF) + ")"
 
     def __repr__(self):
-        return "WholeR1"
+        return "Whole"
 
     def __eq__(self, other):
         return self is Future.convert(other)

--- a/src/rbool/bool1d.py
+++ b/src/rbool/bool1d.py
@@ -5,27 +5,27 @@ This file contains functions to perform boolean operation on 1D subsets
 from numbers import Real
 from typing import Callable, Iterable, List, Set, Union
 
-from .base import EmptyR1, Future, SubSetR1, WholeR1
+from .base import Empty, Future, SubSetR1, Whole
 from .numbs import Is
-from .singles import DisjointR1, IntervalR1, SingleValueR1, bigger, lower
+from .singles import Disjoint, Interval, SingleValue, bigger, lower
 
 
 def extract_knots(obj: SubSetR1) -> Iterable[Real]:
     """
     Extract all the knots from the SubSetR1.
 
-    If it's a SingleValueR1, gives the internal value
-    If it's a IntervalR1, gives the extremities
-    If it's a DisjointR1, use recursion
+    If it's a SingleValue, gives the internal value
+    If it's a Interval, gives the extremities
+    If it's a Disjoint, use recursion
     """
-    if isinstance(obj, SingleValueR1):
+    if isinstance(obj, SingleValue):
         yield obj.internal
-    if isinstance(obj, IntervalR1):
+    if isinstance(obj, Interval):
         if Is.finite(obj[0]):
             yield obj[0]
         if Is.finite(obj[1]):
             yield obj[1]
-    if isinstance(obj, DisjointR1):
+    if isinstance(obj, Disjoint):
         for sub in obj:
             yield from extract_knots(sub)
 
@@ -61,13 +61,13 @@ def general_subset(knots: Iterable[Real], insides: Iterable[bool]) -> SubSetR1:
     Transforms the knots real values and the vector of insides into a SubSetR1
 
     Basically it gets all the knots from a group of subsets:
-    * internal value of SingleValueR1
-    * start and end of an IntervalR1
-    * knots of the internals for case DisjointR1
+    * internal value of SingleValue
+    * start and end of an Interval
+    * knots of the internals for case Disjoint
     and then mark the middle points from the
 
-    Then, this function walks from left to right, deciding which SingleValueR1
-    or IntervalR1 should be gotten to make the return SubSetR1.
+    Then, this function walks from left to right, deciding which SingleValue
+    or Interval should be gotten to make the return SubSetR1.
 
     This is an internal function and should not be used careless
     """
@@ -76,11 +76,11 @@ def general_subset(knots: Iterable[Real], insides: Iterable[bool]) -> SubSetR1:
     if len(insides) != 2 * len(knots) + 1:
         raise ValueError(f"Invalid: knots = {knots}, insides = {insides}")
     if all(insides):
-        return WholeR1()
+        return Whole()
     if not any(insides):
-        return EmptyR1()
+        return Empty()
 
-    items: List[Union[SingleValueR1, IntervalR1]] = []
+    items: List[Union[SingleValue, Interval]] = []
     start: Union[None, Real] = None
     close: bool = False
     for i, knot in enumerate(knots):
@@ -90,13 +90,13 @@ def general_subset(knots: Iterable[Real], insides: Iterable[bool]) -> SubSetR1:
         if left == midd == righ:
             continue
         if not left and not righ:
-            items.append(SingleValueR1(knot))
+            items.append(SingleValue(knot))
             continue
         if left:  # Finish interval
             if start is None:
                 newinterv = lower(knot, midd)
             else:
-                newinterv = IntervalR1(start, knot, close, midd)
+                newinterv = Interval(start, knot, close, midd)
             items.append(newinterv)
             start = None
         if righ:
@@ -109,7 +109,7 @@ def general_subset(knots: Iterable[Real], insides: Iterable[bool]) -> SubSetR1:
     if len(items) == 1:
         return items[0]
 
-    return DisjointR1(items)
+    return Disjoint(items)
 
 
 def unite(*subsets: SubSetR1) -> SubSetR1:

--- a/src/rbool/converter.py
+++ b/src/rbool/converter.py
@@ -2,17 +2,17 @@
 Module that contains functions to convert some basic types into Bool1D types
 
 The easier example is from string:
-* "{}" represents a empty set, so returns the EmptyR1 instance
-* "(-inf, +inf)" represents the entire real line, returns WholeR1 instance
+* "{}" represents a empty set, so returns the Empty instance
+* "(-inf, +inf)" represents the entire real line, returns Whole instance
 """
 
 from numbers import Real
 from typing import Any, Dict, List, Set, Tuple
 
-from .base import EmptyR1, Future, SubSetR1, WholeR1
+from .base import Empty, Future, SubSetR1, Whole
 from .error import NotExpectedError
 from .numbs import NEGINF, POSINF, To
-from .singles import IntervalR1, SingleValueR1, bigger, lower
+from .singles import Interval, SingleValue, bigger, lower
 
 
 # pylint: disable=too-many-return-statements
@@ -32,7 +32,7 @@ def from_any(obj: Any) -> SubSetR1:
         return obj
     if isinstance(obj, Real):
         number = To.finite(obj)
-        return SingleValueR1(number)
+        return SingleValue(number)
     if isinstance(obj, str):
         return from_str(obj)
     if isinstance(obj, dict):
@@ -52,35 +52,35 @@ def from_str(string: str) -> SubSetR1:
 
     Example
     -------
-    >>> from_str("{}")  # EmptyR1
+    >>> from_str("{}")  # Empty
     {}
-    >>> from_str("(-inf, +inf)")  # WholeR1
+    >>> from_str("(-inf, +inf)")  # Whole
     (-inf, +inf)
-    >>> from_str("{10}")  # SingleValueR1
+    >>> from_str("{10}")  # SingleValue
     {10}
-    >>> from_str("[-10, 0] U {5, 10}")  # DisjointR1
+    >>> from_str("[-10, 0] U {5, 10}")  # Disjoint
     [-10, 0] U {5, 10}
     """
     string = string.strip()
     if "U" in string:
         return Future.unite(*map(from_str, string.split("U")))
     if string[0] == "{" and string[-1] == "}":
-        result = EmptyR1()
+        result = Empty()
         for substr in string[1:-1].split(","):
             if not substr:  # Empty string
                 continue
             finite = To.finite(substr)
-            result |= SingleValueR1(finite)
+            result |= SingleValue(finite)
         return result
     if string[0] in "([" and string[-1] in ")]":
         stastr, endstr = string[1:-1].split(",")
         start = To.real(stastr)
         end = To.real(endstr)
         if start == NEGINF and end == POSINF:
-            return WholeR1()
+            return Whole()
         left = string[0] == "["
         right = string[-1] == "]"
-        return IntervalR1(start, end, left, right)
+        return Interval(start, end, left, right)
     raise ValueError(f"Cannot parse '{string}' into a SubSetR1 instance")
 
 
@@ -99,11 +99,11 @@ def from_dict(dic: Dict) -> SubSetR1:
     >>> subset
     {}
     >>> type(subset)
-    <class 'EmptyR1'>
+    <class 'Empty'>
     """
     if not isinstance(dic, dict):
         raise TypeError
-    result = EmptyR1()
+    result = Empty()
     if len(dic) != 0:
         raise NotExpectedError
     return result
@@ -122,11 +122,11 @@ def from_set(items: Set[object]) -> SubSetR1:
     >>> subset
     {-10, 5}
     >>> type(subset)
-    <class 'DisjointR1'>
+    <class 'Disjoint'>
     """
     if not isinstance(items, set):
         raise TypeError
-    result = EmptyR1()
+    result = Empty()
     for item in items:
         result |= To.finite(item)
     return result
@@ -136,7 +136,7 @@ def from_tuple(pair: Tuple[object]) -> SubSetR1:
     """
     Converts a tuple of two values into a SubSetR1 instance
 
-    It's the standard open interval, or the WholeR1
+    It's the standard open interval, or the Whole
 
     Example
     -------
@@ -147,11 +147,11 @@ def from_tuple(pair: Tuple[object]) -> SubSetR1:
     >>> subset
     (-10, 10)
     >>> type(subset)
-    <class 'IntervalR1'>
+    <class 'Interval'>
     >>> variable = ("-inf", "inf")
     >>> subset = from_tuple(variable)
     >>> type(subset)
-    <class 'WholeR1'>
+    <class 'Whole'>
     """
     if not isinstance(pair, tuple):
         raise TypeError
@@ -160,19 +160,19 @@ def from_tuple(pair: Tuple[object]) -> SubSetR1:
     sta = To.real(pair[0])
     end = To.real(pair[1])
     if sta == NEGINF and end == POSINF:
-        return WholeR1()
+        return Whole()
     if sta == NEGINF:
         return lower(end, False)
     if end == POSINF:
         return bigger(sta, False)
-    return IntervalR1(sta, end, False, False)
+    return Interval(sta, end, False, False)
 
 
 def from_list(pair: List[object]) -> SubSetR1:
     """
     Converts a list of two values into a SubSetR1 instance
 
-    It's the standard closed interval, or the WholeR1
+    It's the standard closed interval, or the Whole
 
     Example
     -------
@@ -183,13 +183,13 @@ def from_list(pair: List[object]) -> SubSetR1:
     >>> subset
     [-10, 10]
     >>> type(subset)
-    <class 'IntervalR1'>
+    <class 'Interval'>
     >>> variable = ["-inf", "inf"]
     >>> subset = from_list(variable)
     >>> subset
     (-inf, +inf)
     >>> type(subset)
-    <class 'WholeR1'>
+    <class 'Whole'>
     """
     if not isinstance(pair, list):
         raise TypeError
@@ -198,9 +198,9 @@ def from_list(pair: List[object]) -> SubSetR1:
     sta = To.real(pair[0])
     end = To.real(pair[1])
     if sta == NEGINF and end == POSINF:
-        return WholeR1()
+        return Whole()
     if sta == NEGINF:
         return lower(end, True)
     if end == POSINF:
         return bigger(sta, True)
-    return IntervalR1(sta, end, True, True)
+    return Interval(sta, end, True, True)

--- a/src/rbool/limits.py
+++ b/src/rbool/limits.py
@@ -5,10 +5,10 @@ Contains some functions to compute the limits of the given subsets
 from numbers import Real
 from typing import Union
 
-from .base import EmptyR1, Future, SubSetR1, WholeR1
+from .base import Empty, Future, SubSetR1, Whole
 from .error import NotExpectedError
 from .numbs import NEGINF, POSINF, Is
-from .singles import DisjointR1, IntervalR1, SingleValueR1
+from .singles import Disjoint, Interval, SingleValue
 
 
 def infimum(subset: SubSetR1) -> Union[Real, None]:
@@ -23,33 +23,33 @@ def infimum(subset: SubSetR1) -> Union[Real, None]:
     Return
     ------
     Real | None
-        The infimum value, or None if receives EmptyR1
+        The infimum value, or None if receives Empty
 
     Example
     -------
-    >>> infimum("{}")  # EmptyR1
+    >>> infimum("{}")  # Empty
     None
-    >>> infimum("(-inf, +inf)")  # WholeR1
+    >>> infimum("(-inf, +inf)")  # Whole
     -inf
-    >>> infimum("{-10}")  # SingleValueR1
+    >>> infimum("{-10}")  # SingleValue
     -10
-    >>> infimum("[-10, 10]")  # IntervalR1
+    >>> infimum("[-10, 10]")  # Interval
     -10
-    >>> infimum("(-10, 10)")  # IntervalR1
+    >>> infimum("(-10, 10)")  # Interval
     -10
-    >>> infimum("{0, 10, 20}")  # DisjointR1
+    >>> infimum("{0, 10, 20}")  # Disjoint
     0
     """
     subset = Future.convert(subset)
-    if isinstance(subset, EmptyR1):
+    if isinstance(subset, Empty):
         return None
-    if isinstance(subset, WholeR1):
+    if isinstance(subset, Whole):
         return NEGINF
-    if isinstance(subset, SingleValueR1):
+    if isinstance(subset, SingleValue):
         return subset.internal
-    if isinstance(subset, IntervalR1):
+    if isinstance(subset, Interval):
         return subset[0]
-    if isinstance(subset, DisjointR1):
+    if isinstance(subset, Disjoint):
         return min(map(infimum, subset))
     raise NotExpectedError(f"Received {type(subset)}: {subset}")
 
@@ -70,31 +70,31 @@ def minimum(subset: SubSetR1) -> Union[Real, None]:
 
     Example
     -------
-    >>> minimum("{}")  # EmptyR1
+    >>> minimum("{}")  # Empty
     None
-    >>> minimum("(-inf, +inf)")  # WholeR1
+    >>> minimum("(-inf, +inf)")  # Whole
     None
-    >>> minimum("{-10}")  # SingleValueR1
+    >>> minimum("{-10}")  # SingleValue
     -10
-    >>> minimum("[-10, 10]")  # IntervalR1
+    >>> minimum("[-10, 10]")  # Interval
     -10
-    >>> minimum("(-10, 10)")  # IntervalR1
+    >>> minimum("(-10, 10)")  # Interval
     None
-    >>> minimum("{0, 10, 20}")  # DisjointR1
+    >>> minimum("{0, 10, 20}")  # Disjoint
     0
     """
     subset = Future.convert(subset)
-    if isinstance(subset, (EmptyR1, WholeR1)):
+    if isinstance(subset, (Empty, Whole)):
         return None
-    if isinstance(subset, SingleValueR1):
+    if isinstance(subset, SingleValue):
         return subset.internal
-    if isinstance(subset, IntervalR1):
+    if isinstance(subset, Interval):
         return (
             subset[0]
             if (Is.finite(subset[0]) and subset.closed_left)
             else None
         )
-    if isinstance(subset, DisjointR1):
+    if isinstance(subset, Disjoint):
         infval = POSINF
         global_minval = POSINF
         for sub in subset:
@@ -122,31 +122,31 @@ def maximum(subset: SubSetR1) -> Union[Real, None]:
 
     Example
     -------
-    >>> maximum("{}")  # EmptyR1
+    >>> maximum("{}")  # Empty
     None
-    >>> maximum("(-inf, +inf)")  # WholeR1
+    >>> maximum("(-inf, +inf)")  # Whole
     None
-    >>> maximum("{-10}")  # SingleValueR1
+    >>> maximum("{-10}")  # SingleValue
     -10
-    >>> maximum("[-10, 10]")  # IntervalR1
+    >>> maximum("[-10, 10]")  # Interval
     10
-    >>> maximum("(-10, 10)")  # IntervalR1
+    >>> maximum("(-10, 10)")  # Interval
     None
-    >>> maximum("{0, 10, 20}")  # DisjointR1
+    >>> maximum("{0, 10, 20}")  # Disjoint
     20
     """
     subset = Future.convert(subset)
-    if isinstance(subset, (EmptyR1, WholeR1)):
+    if isinstance(subset, (Empty, Whole)):
         return None
-    if isinstance(subset, SingleValueR1):
+    if isinstance(subset, SingleValue):
         return subset.internal
-    if isinstance(subset, IntervalR1):
+    if isinstance(subset, Interval):
         return (
             subset[1]
             if (Is.finite(subset[1]) and subset.closed_right)
             else None
         )
-    if isinstance(subset, DisjointR1):
+    if isinstance(subset, Disjoint):
         supval = NEGINF
         global_maxval = NEGINF
         for sub in subset:
@@ -170,32 +170,32 @@ def supremum(subset: SubSetR1) -> Union[Real, None]:
     Return
     ------
     Real | None
-        The supremum value, or None if receives EmptyR1
+        The supremum value, or None if receives Empty
 
     Example
     -------
-    >>> supremum("{}")  # EmptyR1
+    >>> supremum("{}")  # Empty
     None
-    >>> supremum("(-inf, +inf)")  # WholeR1
+    >>> supremum("(-inf, +inf)")  # Whole
     +inf
-    >>> supremum("{-10}")  # SingleValueR1
+    >>> supremum("{-10}")  # SingleValue
     -10
-    >>> supremum("[-10, 10]")  # IntervalR1
+    >>> supremum("[-10, 10]")  # Interval
     10
-    >>> supremum("(-10, 10)")  # IntervalR1
+    >>> supremum("(-10, 10)")  # Interval
     10
-    >>> supremum("{0, 10, 20}")  # DisjointR1
+    >>> supremum("{0, 10, 20}")  # Disjoint
     20
     """
     subset = Future.convert(subset)
-    if isinstance(subset, EmptyR1):
+    if isinstance(subset, Empty):
         return None
-    if isinstance(subset, WholeR1):
+    if isinstance(subset, Whole):
         return POSINF
-    if isinstance(subset, SingleValueR1):
+    if isinstance(subset, SingleValue):
         return subset.internal
-    if isinstance(subset, IntervalR1):
+    if isinstance(subset, Interval):
         return subset[1]
-    if isinstance(subset, DisjointR1):
+    if isinstance(subset, Disjoint):
         return max(map(supremum, subset))
     raise NotExpectedError(f"Received {type(subset)}: {subset}")

--- a/src/rbool/singles.py
+++ b/src/rbool/singles.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 from numbers import Real
 from typing import Iterable, List, Set, Tuple, Union
 
-from .base import EmptyR1, Future, SubSetR1
+from .base import Empty, Future, SubSetR1
 from .error import NotExpectedError
 from .numbs import NEGINF, POSINF, Is, To
 
 
-def lower(number: Real, closed: bool = True) -> IntervalR1:
+def lower(number: Real, closed: bool = True) -> Interval:
     """
     Gives the interval such points are lower than given number
 
@@ -25,8 +25,8 @@ def lower(number: Real, closed: bool = True) -> IntervalR1:
 
     Return
     ------
-    IntervalR1
-        The IntervalR1 such is lower than the given `number`
+    Interval
+        The Interval such is lower than the given `number`
 
     Example
     -------
@@ -37,10 +37,10 @@ def lower(number: Real, closed: bool = True) -> IntervalR1:
     >>> lower(10, True)
     (-inf, 10]
     """
-    return IntervalR1(NEGINF, To.finite(number), False, closed)
+    return Interval(NEGINF, To.finite(number), False, closed)
 
 
-def bigger(finite: Real, closed: bool = True) -> IntervalR1:
+def bigger(finite: Real, closed: bool = True) -> Interval:
     """
     Gives the interval such points are bigger than given number
 
@@ -53,8 +53,8 @@ def bigger(finite: Real, closed: bool = True) -> IntervalR1:
 
     Return
     ------
-    IntervalR1
-        The IntervalR1 such is bigger than the given `number`
+    Interval
+        The Interval such is bigger than the given `number`
 
     Example
     -------
@@ -65,12 +65,12 @@ def bigger(finite: Real, closed: bool = True) -> IntervalR1:
     >>> bigger(10, True)
     [10, +inf)
     """
-    return IntervalR1(finite, POSINF, closed, False)
+    return Interval(finite, POSINF, closed, False)
 
 
-class SingleValueR1(SubSetR1):
+class SingleValue(SubSetR1):
     """
-    SingleValueR1 stores only one value, being a subset of the real line
+    SingleValue stores only one value, being a subset of the real line
 
     Only finite values are acceptable
     """
@@ -81,7 +81,7 @@ class SingleValueR1(SubSetR1):
     @property
     def internal(self) -> Real:
         """
-        Gives the internal real value of the SingleValueR1
+        Gives the internal real value of the SingleValue
 
         :getter: Returns the internal value of the SubSetR1
         :type: Real
@@ -92,13 +92,13 @@ class SingleValueR1(SubSetR1):
         return "{" + str(self.__internal) + "}"
 
     def __repr__(self):
-        return f"SingleValueR1({self.__internal})"
+        return f"SingleValue({self.__internal})"
 
     def __contains__(self, other):
         if Is.infinity(other):
             return False
         other = Future.convert(other)
-        return isinstance(other, EmptyR1) or self == other
+        return isinstance(other, Empty) or self == other
 
     def __eq__(self, other):
         other = Future.convert(other)
@@ -108,7 +108,7 @@ class SingleValueR1(SubSetR1):
         )
 
     def __invert__(self):
-        return DisjointR1(
+        return Disjoint(
             [
                 lower(self.internal, False),
                 bigger(self.internal, False),
@@ -117,15 +117,15 @@ class SingleValueR1(SubSetR1):
 
     def __and__(self, other: SubSetR1):
         other = Future.convert(other)
-        return self if other.__contains__(self) else EmptyR1()
+        return self if other.__contains__(self) else Empty()
 
     def __hash__(self):
         return hash(self.internal)
 
 
-class IntervalR1(SubSetR1):
+class Interval(SubSetR1):
     """
-    IntervalR1 stores a continuous set of points on R1
+    Interval stores a continuous set of points on R1
 
 
     """
@@ -140,7 +140,7 @@ class IntervalR1(SubSetR1):
                 "Received interval [{start}, {end}], but {end} <= {start}"
             )
         if Is.infinity(start) and Is.infinity(end):
-            raise ValueError("Received interval (-inf, +inf), use WholeR1")
+            raise ValueError("Received interval (-inf, +inf), use Whole")
         if start == NEGINF:
             left = False
         if end == POSINF:
@@ -155,14 +155,14 @@ class IntervalR1(SubSetR1):
         if Is.infinity(other):
             return other in (self[0], self[1])
         other = Future.convert(other)
-        if isinstance(other, SingleValueR1):
+        if isinstance(other, SingleValue):
             other = other.internal
             if other < self[0] or self[1] < other:
                 return False
             if self[0] < other < self[1]:
                 return True
             return self.closed_left if self[0] == other else self.closed_right
-        if isinstance(other, IntervalR1):
+        if isinstance(other, Interval):
             if other[0] < self[0] or self[1] < other[1]:
                 return False
             if self[0] < other[0] and other[1] < self[1]:
@@ -174,16 +174,16 @@ class IntervalR1(SubSetR1):
             ):
                 return False
             return True
-        if isinstance(other, DisjointR1):
+        if isinstance(other, Disjoint):
             return all(map(self.__contains__, other))
-        return isinstance(other, EmptyR1)
+        return isinstance(other, Empty)
 
     def __invert__(self):
         if self[0] == NEGINF:
             return bigger(self[1], not self.closed_right)
         if self[1] == POSINF:
             return lower(self[0], not self.closed_left)
-        return DisjointR1(
+        return Disjoint(
             [
                 lower(self[0], not self.closed_left),
                 bigger(self[1], not self.closed_right),
@@ -196,7 +196,7 @@ class IntervalR1(SubSetR1):
     def __eq__(self, other):
         other = Future.convert(other)
         return (
-            isinstance(other, IntervalR1)
+            isinstance(other, Interval)
             and self[0] == other[0]
             and self[1] == other[1]
             and self.closed_left == other.closed_left
@@ -233,28 +233,28 @@ class IntervalR1(SubSetR1):
         return hash((self[0], self[1]))
 
 
-class DisjointR1(SubSetR1):
+class Disjoint(SubSetR1):
     """
-    Stores the union of SingleValueR1 and IntervalR1 which are not connected
+    Stores the union of SingleValue and Interval which are not connected
 
     The direct constructor should not be used.
     This object should be constructed by the standard boolean operations
-    of the some SingleValueR1 and IntervalR1
+    of the some SingleValue and Interval
     """
 
-    def __init__(self, items: Iterable[Union[SingleValueR1, IntervalR1]]):
+    def __init__(self, items: Iterable[Union[SingleValue, Interval]]):
         items = tuple(items)
         if len(items) < 2:
             raise ValueError("Less than 2 items!")
 
         knots: Set[Real] = set()
-        singles: List[SingleValueR1] = []
-        intervs: List[IntervalR1] = []
+        singles: List[SingleValue] = []
+        intervs: List[Interval] = []
         for item in items:
-            if isinstance(item, SingleValueR1):
+            if isinstance(item, SingleValue):
                 singles.append(item)
                 knots.add(item.internal)
-            elif isinstance(item, IntervalR1):
+            elif isinstance(item, Interval):
                 intervs.append(item)
                 if isinstance(item[0], Real):
                     knots.add(item[0])
@@ -273,22 +273,22 @@ class DisjointR1(SubSetR1):
         )
 
     @property
-    def singles(self) -> Tuple[SingleValueR1, ...]:
+    def singles(self) -> Tuple[SingleValue, ...]:
         """
-        Gives all the isolated nodes that are inside the DisjointR1
+        Gives all the isolated nodes that are inside the Disjoint
 
         :getter: Returns all the isolated points
-        :type: Tuple[SingleValueR1, ...]
+        :type: Tuple[SingleValue, ...]
         """
         return self.__singles
 
     @property
-    def intervals(self) -> Tuple[IntervalR1, ...]:
+    def intervals(self) -> Tuple[Interval, ...]:
         """
-        Gives all the non-connected intervals that are inside the DisjointR1
+        Gives all the non-connected intervals that are inside the Disjoint
 
         :getter: Returns all the non-connected intervals
-        :type: Tuple[SingleValueR1, ...]
+        :type: Tuple[SingleValue, ...]
         """
         return self.__intervs
 
@@ -300,7 +300,7 @@ class DisjointR1(SubSetR1):
         if Is.infinity(other):
             return any(other in sub for sub in self)
         other = Future.convert(other)
-        if isinstance(other, DisjointR1):
+        if isinstance(other, Disjoint):
             return all(sub in self for sub in other)
         return any(other in sub for sub in self)
 
@@ -372,7 +372,7 @@ class DisjointR1(SubSetR1):
 
     def __eq__(self, other):
         other = Future.convert(other)
-        if not isinstance(other, DisjointR1):
+        if not isinstance(other, Disjoint):
             return False
         if len(self.singles) != len(other.singles) or len(
             self.intervals

--- a/src/rbool/transform.py
+++ b/src/rbool/transform.py
@@ -5,10 +5,10 @@ like translating, scaling and rotating the SubSetR2 instances on the plane
 
 from numbers import Real
 
-from .base import EmptyR1, Future, SubSetR1, WholeR1
+from .base import Empty, Future, SubSetR1, Whole
 from .error import NotExpectedError
 from .numbs import To
-from .singles import DisjointR1, IntervalR1, SingleValueR1
+from .singles import Disjoint, Interval, SingleValue
 
 
 def move(subset: SubSetR1, amount: Real) -> SubSetR1:
@@ -29,20 +29,20 @@ def move(subset: SubSetR1, amount: Real) -> SubSetR1:
     """
     subset = Future.convert(subset)
     amount = To.finite(amount)
-    if isinstance(subset, (EmptyR1, WholeR1)):
+    if isinstance(subset, (Empty, Whole)):
         return subset
-    if isinstance(subset, SingleValueR1):
-        return SingleValueR1(subset.internal + amount)
-    if isinstance(subset, IntervalR1):
+    if isinstance(subset, SingleValue):
+        return SingleValue(subset.internal + amount)
+    if isinstance(subset, Interval):
         newlef = subset[0] + amount
         newrig = subset[1] + amount
-        return IntervalR1(
+        return Interval(
             newlef, newrig, subset.closed_left, subset.closed_right
         )
-    if isinstance(subset, DisjointR1):
+    if isinstance(subset, Disjoint):
         amount = To.finite(amount)
         newiterable = (move(sub, amount) for sub in subset)
-        return DisjointR1(newiterable)
+        return Disjoint(newiterable)
     raise NotExpectedError(f"Missing typo? {type(subset)}")
 
 
@@ -72,11 +72,11 @@ def scale(subset: SubSetR1, amount: Real) -> SubSetR1:
     amount = To.finite(amount)
     if amount == 0:
         raise ValueError
-    if isinstance(subset, (EmptyR1, WholeR1)):
+    if isinstance(subset, (Empty, Whole)):
         return subset
-    if isinstance(subset, SingleValueR1):
-        return SingleValueR1(subset.internal * amount)
-    if isinstance(subset, IntervalR1):
+    if isinstance(subset, SingleValue):
+        return SingleValue(subset.internal * amount)
+    if isinstance(subset, Interval):
         newlef = subset[0] * amount
         newrig = subset[1] * amount
         clolef = subset.closed_left
@@ -84,9 +84,9 @@ def scale(subset: SubSetR1, amount: Real) -> SubSetR1:
         if amount < 0:
             newlef, newrig = newrig, newlef
             clolef, clorig = clorig, clolef
-        return IntervalR1(newlef, newrig, clolef, clorig)
-    if isinstance(subset, DisjointR1):
+        return Interval(newlef, newrig, clolef, clorig)
+    if isinstance(subset, Disjoint):
         amount = To.finite(amount)
         newiterable = (scale(sub, amount) for sub in subset)
-        return DisjointR1(newiterable)
+        return Disjoint(newiterable)
     raise NotExpectedError(f"Missing typo? {type(subset)}")

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -1,14 +1,6 @@
 import pytest
 
-from rbool import (
-    EmptyR1,
-    IntervalR1,
-    SingleValueR1,
-    WholeR1,
-    bigger,
-    from_any,
-    lower,
-)
+from rbool import Empty, Interval, SingleValue, Whole, bigger, from_any, lower
 
 
 @pytest.mark.order(16)
@@ -32,8 +24,8 @@ class TestInversion:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_singletion(self):
-        empty = EmptyR1()
-        whole = WholeR1()
+        empty = Empty()
+        whole = Whole()
 
         assert ~empty == whole
         assert ~whole == empty
@@ -42,9 +34,9 @@ class TestInversion:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_single(self):
-        assert ~SingleValueR1(0) == "(-inf, 0) U (0, inf)"
-        assert ~SingleValueR1(-10) == "(-inf, -10) U (-10, inf)"
-        assert ~SingleValueR1(+10) == "(-inf, 10) U (10, inf)"
+        assert ~SingleValue(0) == "(-inf, 0) U (0, inf)"
+        assert ~SingleValue(-10) == "(-inf, -10) U (-10, inf)"
+        assert ~SingleValue(+10) == "(-inf, 10) U (10, inf)"
 
     @pytest.mark.order(16)
     @pytest.mark.timeout(1)
@@ -91,8 +83,8 @@ class TestAndOr:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_singleton(self):
-        empty = EmptyR1()
-        whole = WholeR1()
+        empty = Empty()
+        whole = Whole()
 
         assert empty & empty == empty
         assert whole & empty == empty
@@ -118,11 +110,11 @@ class TestAndOr:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_single_singleton(self):
-        empty = EmptyR1()
-        whole = WholeR1()
+        empty = Empty()
+        whole = Whole()
 
         for value in (-10, 0, 10):
-            single = SingleValueR1(value)
+            single = SingleValue(value)
             assert single & empty == empty
             assert single & whole == single
             assert empty & single == empty
@@ -158,10 +150,10 @@ class TestAndOr:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_single_single(self):
-        empty = EmptyR1()
+        empty = Empty()
 
         values = (-10, 0, 10)
-        singles = tuple(map(SingleValueR1, values))
+        singles = tuple(map(SingleValue, values))
         for i, (vali, singi) in enumerate(zip(values, singles)):
             for j, (valj, singj) in enumerate(zip(values, singles)):
                 if i == j:
@@ -201,7 +193,7 @@ class TestAndOr:
     def test_interval_contains_disjoint(self):
         string = "{-30, -25} U [-20, 20] U {25, 30, 40}"
         disjoint = from_any(string)
-        assert disjoint in IntervalR1(-50, 50)
+        assert disjoint in Interval(-50, 50)
 
     @pytest.mark.order(16)
     @pytest.mark.timeout(1)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rbool import EmptyR1, IntervalR1, SingleValueR1, WholeR1
+from rbool import Empty, Interval, SingleValue, Whole
 
 
 @pytest.mark.order(12)
@@ -14,8 +14,8 @@ def test_begin():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_empty():
-    empty1 = EmptyR1()
-    empty2 = EmptyR1()
+    empty1 = Empty()
+    empty2 = Empty()
     assert id(empty1) == id(empty2)
     assert empty1 is empty2
 
@@ -26,8 +26,8 @@ def test_empty():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_whole():
-    whole1 = WholeR1()
-    whole2 = WholeR1()
+    whole1 = Whole()
+    whole2 = Whole()
     assert id(whole1) == id(whole2)
     assert whole1 is whole2
 
@@ -38,33 +38,33 @@ def test_whole():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_single():
-    SingleValueR1(-10)
-    SingleValueR1(0)
-    SingleValueR1(10)
+    SingleValue(-10)
+    SingleValue(0)
+    SingleValue(10)
 
-    SingleValueR1(-10.0)
-    SingleValueR1(0.0)
-    SingleValueR1(10.0)
+    SingleValue(-10.0)
+    SingleValue(0.0)
+    SingleValue(10.0)
 
     with pytest.raises(ValueError):
-        SingleValueR1(float("-inf"))
+        SingleValue(float("-inf"))
     with pytest.raises(ValueError):
-        SingleValueR1(float("inf"))
+        SingleValue(float("inf"))
 
-    hash(SingleValueR1(10))
+    hash(SingleValue(10))
 
 
 @pytest.mark.order(12)
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_interval():
-    IntervalR1(-10, 10)
-    IntervalR1(float("-inf"), 10)
-    IntervalR1(-10, float("inf"))
+    Interval(-10, 10)
+    Interval(float("-inf"), 10)
+    Interval(-10, float("inf"))
     with pytest.raises(ValueError):
-        IntervalR1(float("-inf"), float("inf"))
+        Interval(float("-inf"), float("inf"))
 
-    hash(IntervalR1(-10, 10))
+    hash(Interval(-10, 10))
 
 
 @pytest.mark.order(12)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rbool import EmptyR1, IntervalR1, SingleValueR1, WholeR1
+from rbool import Empty, Interval, SingleValue, Whole
 from rbool.numbs import NEGINF, POSINF
 
 
@@ -21,7 +21,7 @@ def test_begin():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_empty():
-    empty = EmptyR1()
+    empty = Empty()
 
     assert empty == empty
     assert empty == {}
@@ -32,7 +32,7 @@ def test_empty():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_whole():
-    whole = WholeR1()
+    whole = Whole()
 
     assert whole == whole
     assert whole == (float("-inf"), float("inf"))
@@ -50,8 +50,8 @@ def test_whole():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_empty", "test_whole"])
 def test_singletons():
-    empty = EmptyR1()
-    whole = WholeR1()
+    empty = Empty()
+    whole = Whole()
 
     assert empty == empty
     assert empty != whole
@@ -68,11 +68,11 @@ def test_singletons():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_singletons"])
 def test_singles():
-    empty = EmptyR1()
-    whole = WholeR1()
+    empty = Empty()
+    whole = Whole()
 
     for value in (-10, 0, 10):
-        single = SingleValueR1(value)
+        single = SingleValue(value)
         assert single == single
         assert single == value
         assert single == {value}
@@ -93,16 +93,16 @@ def test_singles():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_singletons", "test_singles"])
 def test_intervals():
-    empty = EmptyR1()
-    whole = WholeR1()
+    empty = Empty()
+    whole = Whole()
 
     aval, bval = -10, 10
 
-    n2a = IntervalR1(NEGINF, aval)
-    n2b = IntervalR1(NEGINF, bval)
-    a2b = IntervalR1(aval, bval)
-    a2p = IntervalR1(aval, POSINF)
-    b2p = IntervalR1(bval, POSINF)
+    n2a = Interval(NEGINF, aval)
+    n2b = Interval(NEGINF, bval)
+    a2b = Interval(aval, bval)
+    a2p = Interval(aval, POSINF)
+    b2p = Interval(bval, POSINF)
 
     intervals = (n2a, n2b, a2b, a2p, b2p)
     for i, intvi in enumerate(intervals):
@@ -135,7 +135,7 @@ def test_intervals():
         (20, POSINF),
     ]
     for sta, end in closed_pairs:
-        interv = IntervalR1(sta, end, True, True)
+        interv = Interval(sta, end, True, True)
         assert interv == [sta, end]
         assert [sta, end] == interv
 
@@ -151,7 +151,7 @@ def test_intervals():
         (20, POSINF),
     ]
     for sta, end in open_pairs:
-        interv = IntervalR1(sta, end, False, False)
+        interv = Interval(sta, end, False, False)
         assert interv == (sta, end)
         assert (sta, end) == interv
 

--- a/tests/test_contains.py
+++ b/tests/test_contains.py
@@ -1,11 +1,11 @@
 import pytest
 
 from rbool import (
-    DisjointR1,
-    EmptyR1,
-    IntervalR1,
-    SingleValueR1,
-    WholeR1,
+    Disjoint,
+    Empty,
+    Interval,
+    SingleValue,
+    Whole,
     bigger,
     contains,
     from_any,
@@ -32,8 +32,8 @@ def test_begin():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_singleton_in_singleton():
-    empty = EmptyR1()
-    whole = WholeR1()
+    empty = Empty()
+    whole = Whole()
 
     assert empty in empty
     assert empty in whole
@@ -51,11 +51,11 @@ def test_singleton_in_singleton():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_singleton_contains_object():
-    empty = EmptyR1()
-    whole = WholeR1()
+    empty = Empty()
+    whole = Whole()
 
     values = (-100, -50, -20, -10, 0, 10, 20, 50, 100)
-    singls = tuple(map(SingleValueR1, values))
+    singls = tuple(map(SingleValue, values))
     for value in values:
         assert value not in empty
         assert value in whole
@@ -67,11 +67,11 @@ def test_singleton_contains_object():
 
     aval, bval = -10, 10
 
-    n2a = IntervalR1(NEGINF, aval)
-    n2b = IntervalR1(NEGINF, bval)
-    a2b = IntervalR1(aval, bval)
-    a2p = IntervalR1(aval, POSINF)
-    b2p = IntervalR1(bval, POSINF)
+    n2a = Interval(NEGINF, aval)
+    n2b = Interval(NEGINF, bval)
+    a2b = Interval(aval, bval)
+    a2p = Interval(aval, POSINF)
+    b2p = Interval(bval, POSINF)
     intervals = (n2a, n2b, a2b, a2p, b2p)
     for interval in intervals:
         assert empty in interval
@@ -87,11 +87,11 @@ def test_interval_contains_interval():
 
     aval, bval = -10, 10
 
-    n2a = IntervalR1(NEGINF, aval)
-    n2b = IntervalR1(NEGINF, bval)
-    a2b = IntervalR1(aval, bval)
-    a2p = IntervalR1(aval, POSINF)
-    b2p = IntervalR1(bval, POSINF)
+    n2a = Interval(NEGINF, aval)
+    n2b = Interval(NEGINF, bval)
+    a2b = Interval(aval, bval)
+    a2p = Interval(aval, POSINF)
+    b2p = Interval(bval, POSINF)
 
     assert n2a in n2a
     assert n2a in n2b
@@ -123,15 +123,11 @@ def test_interval_contains_interval():
     assert b2p in a2p
     assert b2p in b2p
 
-    assert IntervalR1(-50, -20) not in IntervalR1(0, 20)
-    assert IntervalR1(10, 50) not in IntervalR1(0, 20)
-    assert IntervalR1(-10, 10) in IntervalR1(-20, 20)
-    assert IntervalR1(-10, 10, True, True) not in IntervalR1(
-        -20, 10, True, False
-    )
-    assert IntervalR1(-10, 10, True, True) not in IntervalR1(
-        -10, 20, False, True
-    )
+    assert Interval(-50, -20) not in Interval(0, 20)
+    assert Interval(10, 50) not in Interval(0, 20)
+    assert Interval(-10, 10) in Interval(-20, 20)
+    assert Interval(-10, 10, True, True) not in Interval(-20, 10, True, False)
+    assert Interval(-10, 10, True, True) not in Interval(-10, 20, False, True)
 
 
 @pytest.mark.order(15)
@@ -148,7 +144,7 @@ def test_disjoint_contains_object():
     ]
     string = " U ".join(blocks)
     disjoint = from_any(string)
-    assert isinstance(disjoint, DisjointR1)
+    assert isinstance(disjoint, Disjoint)
 
     inside = {-25, -10, -7, -5, 0, 2, 12, 15, 22, 30, 31, 33}
     outside = {-20, -15, -2, 5, 7, 10, 17, 20, 25, 28, 32}
@@ -161,31 +157,31 @@ def test_disjoint_contains_object():
     assert disjoint != {30, 31}
     assert disjoint != [-10, -5]
     assert disjoint != {30}
-    assert disjoint != EmptyR1()
-    assert disjoint != WholeR1()
+    assert disjoint != Empty()
+    assert disjoint != Whole()
 
     assert {30, 31} in disjoint
     assert [-10, -5] in disjoint
     assert {30} in disjoint
-    assert EmptyR1() in disjoint
-    assert WholeR1() not in disjoint
+    assert Empty() in disjoint
+    assert Whole() not in disjoint
 
 
 @pytest.mark.order(15)
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_infinity():
-    empty = EmptyR1()
+    empty = Empty()
     assert NEGINF not in empty
     assert POSINF not in empty
 
-    whole = WholeR1()
+    whole = Whole()
     assert NEGINF in whole
     assert POSINF in whole
 
     for value in (-10, -1, 0, 1, 10):
-        assert NEGINF not in SingleValueR1(value)
-        assert POSINF not in SingleValueR1(value)
+        assert NEGINF not in SingleValue(value)
+        assert POSINF not in SingleValue(value)
 
     interval = lower(0)
     assert NEGINF in interval
@@ -195,7 +191,7 @@ def test_infinity():
     assert NEGINF not in interval
     assert POSINF in interval
 
-    interval = IntervalR1(-10, 10)
+    interval = Interval(-10, 10)
     assert NEGINF not in interval
     assert POSINF not in interval
 
@@ -209,7 +205,7 @@ def test_infinity():
     ]
     string = " U ".join(blocks)
     disjoint = from_any(string)
-    assert isinstance(disjoint, DisjointR1)
+    assert isinstance(disjoint, Disjoint)
 
     assert NEGINF in disjoint
     assert POSINF not in disjoint

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,14 +1,6 @@
 import pytest
 
-from rbool import (
-    EmptyR1,
-    IntervalR1,
-    SingleValueR1,
-    WholeR1,
-    bigger,
-    from_any,
-    lower,
-)
+from rbool import Empty, Interval, SingleValue, Whole, bigger, from_any, lower
 
 
 @pytest.mark.order(13)
@@ -29,31 +21,31 @@ class TestFromString:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_empty(self):
-        assert from_any("{}") == EmptyR1()
+        assert from_any("{}") == Empty()
 
     @pytest.mark.order(13)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_whole(self):
-        assert from_any("(-inf, inf)") == WholeR1()
+        assert from_any("(-inf, inf)") == Whole()
 
     @pytest.mark.order(13)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_single(self):
-        assert from_any(r"{-10}") == SingleValueR1(-10)
-        assert from_any(r"{0}") == SingleValueR1(0)
-        assert from_any(r"{10}") == SingleValueR1(10)
-        assert from_any(r"{+10}") == SingleValueR1(10)
+        assert from_any(r"{-10}") == SingleValue(-10)
+        assert from_any(r"{0}") == SingleValue(0)
+        assert from_any(r"{10}") == SingleValue(10)
+        assert from_any(r"{+10}") == SingleValue(10)
 
     @pytest.mark.order(13)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_interval(self):
-        assert from_any(r"[-10, 10]") == IntervalR1(-10, 10, True, True)
-        assert from_any(r"[-10, 10)") == IntervalR1(-10, 10, True, False)
-        assert from_any(r"(-10, 10]") == IntervalR1(-10, 10, False, True)
-        assert from_any(r"(-10, 10)") == IntervalR1(-10, 10, False, False)
+        assert from_any(r"[-10, 10]") == Interval(-10, 10, True, True)
+        assert from_any(r"[-10, 10)") == Interval(-10, 10, True, False)
+        assert from_any(r"(-10, 10]") == Interval(-10, 10, False, True)
+        assert from_any(r"(-10, 10)") == Interval(-10, 10, False, False)
 
         assert from_any(r"(-inf, 10]") == lower(10, True)
         assert from_any(r"(-inf, 10)") == lower(10, False)

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,14 +1,6 @@
 import pytest
 
-from rbool import (
-    DisjointR1,
-    EmptyR1,
-    IntervalR1,
-    SingleValueR1,
-    WholeR1,
-    bigger,
-    lower,
-)
+from rbool import Disjoint, Empty, Interval, SingleValue, Whole, bigger, lower
 
 
 @pytest.mark.order(14)
@@ -28,51 +20,51 @@ def test_begin():
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_empty():
-    empty = EmptyR1()
+    empty = Empty()
     assert str(empty) == r"{}"
-    assert repr(empty) == r"EmptyR1"
+    assert repr(empty) == r"Empty"
 
 
 @pytest.mark.order(14)
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_whole():
-    whole = WholeR1()
+    whole = Whole()
     assert str(whole) == r"(-inf, inf)"
-    assert repr(whole) == r"WholeR1"
+    assert repr(whole) == r"Whole"
 
 
 @pytest.mark.order(14)
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_single():
-    value = SingleValueR1(-10)
+    value = SingleValue(-10)
     assert str(value) == r"{-10}"
-    assert repr(value) == r"SingleValueR1(-10)"
+    assert repr(value) == r"SingleValue(-10)"
 
-    value = SingleValueR1(0)
+    value = SingleValue(0)
     assert str(value) == r"{0}"
-    assert repr(value) == r"SingleValueR1(0)"
+    assert repr(value) == r"SingleValue(0)"
 
-    value = SingleValueR1(10)
+    value = SingleValue(10)
     assert str(value) == r"{10}"
-    assert repr(value) == r"SingleValueR1(10)"
+    assert repr(value) == r"SingleValue(10)"
 
 
 @pytest.mark.order(14)
 @pytest.mark.timeout(1)
 @pytest.mark.dependency(depends=["test_begin"])
 def test_interval():
-    interval = IntervalR1(-10, 10, True, True)
+    interval = Interval(-10, 10, True, True)
     assert str(interval) == r"[-10, 10]"
 
-    interval = IntervalR1(-10, 10, True, False)
+    interval = Interval(-10, 10, True, False)
     assert str(interval) == r"[-10, 10)"
 
-    interval = IntervalR1(-10, 10, False, True)
+    interval = Interval(-10, 10, False, True)
     assert str(interval) == r"(-10, 10]"
 
-    interval = IntervalR1(-10, 10, False, False)
+    interval = Interval(-10, 10, False, False)
     assert str(interval) == r"(-10, 10)"
 
     interval = lower(10, True)
@@ -94,13 +86,13 @@ def test_interval():
 def test_disjoint():
     interv0 = lower(-50)
     interv1 = bigger(50)
-    disjoint = DisjointR1([interv0, interv1])
+    disjoint = Disjoint([interv0, interv1])
     assert str(disjoint) == "(-inf, -50] U [50, inf)"
     repr(disjoint)
 
-    interv2 = IntervalR1(-20, 20)
-    singles = list(map(SingleValueR1, [-30, -25, 25, 30, 40]))
-    disjoint = DisjointR1([interv0, interv1, interv2] + singles)
+    interv2 = Interval(-20, 20)
+    singles = list(map(SingleValue, [-30, -25, 25, 30, 40]))
+    disjoint = Disjoint([interv0, interv1, interv2] + singles)
     blocks = [
         "(-inf, -50]",
         "{-30, -25}",
@@ -111,12 +103,12 @@ def test_disjoint():
     assert str(disjoint) == " U ".join(blocks)
     repr(disjoint)
 
-    disjoint = DisjointR1([interv0, interv2] + singles)
+    disjoint = Disjoint([interv0, interv2] + singles)
     blocks = ["(-inf, -50]", "{-30, -25}", "[-20, 20]", "{25, 30, 40}"]
     assert str(disjoint) == " U ".join(blocks)
     repr(disjoint)
 
-    disjoint = DisjointR1(singles)
+    disjoint = Disjoint(singles)
     assert str(disjoint) == "{-30, -25, 25, 30, 40}"
     repr(disjoint)
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,14 +1,6 @@
 import pytest
 
-from rbool import (
-    EmptyR1,
-    IntervalR1,
-    SingleValueR1,
-    WholeR1,
-    from_any,
-    move,
-    scale,
-)
+from rbool import Empty, Interval, SingleValue, Whole, from_any, move, scale
 
 
 @pytest.mark.order(17)
@@ -32,7 +24,7 @@ class TestShift:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_empty(self):
-        empty = EmptyR1()
+        empty = Empty()
         assert empty.move(-1) == empty
         assert empty.move(0) == empty
         assert empty.move(1) == empty
@@ -45,7 +37,7 @@ class TestShift:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_whole(self):
-        whole = WholeR1()
+        whole = Whole()
         assert whole.move(-1) == whole
         assert whole.move(0) == whole
         assert whole.move(1) == whole
@@ -62,10 +54,10 @@ class TestShift:
         amounts = [-20, -10, 0, 10, 20]
 
         for value in values:
-            single = SingleValueR1(value)
+            single = SingleValue(value)
             for amount in amounts:
                 test = single.move(amount)
-                good = SingleValueR1(value + amount)
+                good = SingleValue(value + amount)
                 assert test == good
 
             with pytest.raises(ValueError):
@@ -77,9 +69,9 @@ class TestShift:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_interval(self):
-        base = IntervalR1(-10, 10)
+        base = Interval(-10, 10)
         test = base.move(-5)
-        good = IntervalR1(-15, 5)
+        good = Interval(-15, 5)
         assert test == good
 
     @pytest.mark.order(17)
@@ -112,7 +104,7 @@ class TestScale:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_empty(self):
-        empty = EmptyR1()
+        empty = Empty()
         assert empty.scale(-1) == empty
         assert empty.scale(1) == empty
 
@@ -123,7 +115,7 @@ class TestScale:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_whole(self):
-        whole = WholeR1()
+        whole = Whole()
         assert whole.scale(-1) == whole
         assert whole.scale(1) == whole
 
@@ -138,10 +130,10 @@ class TestScale:
         amounts = [-20, -10, 10, 20]
 
         for value in values:
-            single = SingleValueR1(value)
+            single = SingleValue(value)
             for amount in amounts:
                 test = single.scale(amount)
-                good = SingleValueR1(value * amount)
+                good = SingleValue(value * amount)
                 assert test == good
 
             with pytest.raises(ValueError):
@@ -155,15 +147,15 @@ class TestScale:
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_interval(self):
-        base = IntervalR1(-10, 10)
+        base = Interval(-10, 10)
         assert base.scale(1) == base
-        assert base.scale(2) == IntervalR1(-20, 20)
+        assert base.scale(2) == Interval(-20, 20)
         assert base.scale(-1) == base  # symmetry
 
-        base = IntervalR1(0, 10)
+        base = Interval(0, 10)
         assert base.scale(1) == base
-        assert base.scale(2) == IntervalR1(0, 20)
-        assert base.scale(-1) == IntervalR1(-10, 0)
+        assert base.scale(2) == Interval(0, 20)
+        assert base.scale(-1) == Interval(-10, 0)
 
         base = from_any("[-10, 5)")
         assert base.scale(1) == base


### PR DESCRIPTION
Rename usual classes to remove the suffix `R1`:
* `EmptyR1` to `Empty`
* `WholeR1` to `Whole`
* `SingleValueR1` to `SingleValue`
* `IntervalR1` to `Interval`
* `DisjointR1` to `Disjoint`