### PR TITLE
Fix: converting string into integers and rationals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "rbool"
-version = "0.0.2"
+version = "0.0.3"
 description = "1D boolean operations"
 authors = ["Carlos Adir <carlos.adir.leite@gmail.com>"]
 readme = "README.md"

--- a/src/rbool/numbs.py
+++ b/src/rbool/numbs.py
@@ -64,6 +64,17 @@ class To:
         """
         if isinstance(number, Real):
             return number
+        if isinstance(number, str):
+            if "/" in number:
+                parts = tuple(map(To.real, number.split("/")))
+                number = To.rational(parts[0], 1)
+                for denom in parts[1:]:
+                    number /= denom
+                return To.real(number)
+            try:
+                return To.integer(number)
+            except ValueError:
+                pass
         return float(number)
 
     @staticmethod

--- a/tests/test_numbers.py
+++ b/tests/test_numbers.py
@@ -30,6 +30,12 @@ def test_to():
     with pytest.raises(ValueError):
         To.finite("inf")
 
+    assert To.real("1") == 1
+    assert isinstance(To.real("1"), int)
+    assert isinstance(To.real("-3"), int)
+
+    assert To.real("1/3") == To.rational(1, 3)
+
 
 @pytest.mark.order(1)
 @pytest.mark.timeout(1)


### PR DESCRIPTION
As described by #5, the actual behaviour is:

```python
>>> from rbool import *
>>> from_any("{-5, 3}")
{-5.0, 3.0}
```

This PR sets to:

```python
>>> from_any("{-5, 3/7}")
{-5, 3/7}
```

The first one is transformed to integer, while the second is to fractions